### PR TITLE
Upgrade react-mardown to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "peerDependencies": {
     "react": "^15.4.2",
-    "react-markdown": "^2.4.5"
+    "react-markdown": "^2.5.0"
   },
   "license": "ISC"
 }


### PR DESCRIPTION
It seems that [2.4.5 is not a valid version](https://github.com/rexxars/react-markdown/releases) for `react-mardown`.

I was getting this error when trying to install :
```
> npm install -s reactmd-brunch
├── UNMET PEER DEPENDENCY react-markdown@^2.4.5
└── reactmd-brunch@0.1.4 
```

Updating it to the last version (`2.5.0`) fixed this install issue.